### PR TITLE
update for compatibility with Joi 16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## 4.0.0
+
+- BREAKING CHANGE: Require [@hapi/joi][] ^16.0.0.
+- BREAKING CHANGE: module now exports an object.
+
+  If you have existing code like
+
+  ```js
+  const semver = require('joi-extension-semver')
+  const Joi = require('@hapi/joi').extend(semver)
+  ```
+
+  update it to
+
+  ```js
+  const { semver } = require('joi-extension-semver')
+  const Joi = require('@hapi/joi').extend(semver)
+  ```
+
+- BREAKING CHANGE: `semverRange` is now a seperate type from `semver`.
+
+  If you have existing code that calls `.validRange()` like
+
+  ```js
+  const semver = require('joi-extension-semver')
+  const Joi = require('@hapi/joi').extend(semver)
+  Joi.attempt('>=1.2.3', Joi.semver().validRange())
+  ```
+
+  update it to
+
+  ```js
+  const { semverRange } = require('joi-extension-semver')
+  const Joi = require('@hapi/joi').extend(semverRange)
+  Joi.attempt('>=1.2.3', Joi.semverRange().valid())
+  ```
 
 ## 3.0.0
 

--- a/README.MD
+++ b/README.MD
@@ -7,13 +7,17 @@ Semver extension for the Joi validation library
 ## Usage
 
 ```js
-
+const { semver, semverRange } = require('joi-extension-semver')
 const Joi = require('@hapi/joi')
-  .extend(require('joi-extension-semver'))
+    .extend(semver)
+    .extend(semverRange)
 
-Joi.attempt('1.2.3', joi.semver().gte('1.2.3')) // 1.2.3
-Joi.attempt('1.2.3', joi.semver().lt('1.2.3')) // throws ValidationError
-Joi.attempt('1.2.3', joi.semver().satisfies('^1.0.0')) // 1.2.3
+Joi.attempt('1.2.3', Joi.semver().valid()) // '1.2.3'
+Joi.attempt('>=1.2.3', Joi.semverRange().valid()) // '>=1.2.3'
+
+Joi.attempt('1.2.3', Joi.semver().gte('1.2.3')) // '1.2.3'
+Joi.attempt('1.2.3', Joi.semver().lt('1.2.3')) // throws ValidationError
+Joi.attempt('1.2.3', Joi.semver().satisfies('^1.0.0')) // '1.2.3'
 ```
 
 ## Validation chains
@@ -31,40 +35,45 @@ returning comparisons are supported.
     - [`semver.eq(exp)`](#semvereqexp)
     - [`semver.neq(exp)`](#semverneqexp)
     - [`semver.cmp(cmp, exp)`](#semvercmpcmp-exp)
-    - [`semver.validRange()`](#semvervalidrange)
     - [`semver.satisfies(rng)`](#semversatisfiesrng)
     - [`semver.gtr(rng)`](#semvergtrrng)
     - [`semver.ltr(rng)`](#semverltrrng)
     - [`semver.outside(hilo, rng)`](#semveroutsidehilo-rng)
+  - [`semverRange`](#semverRange)
+    - [`semverRange.valid()`](#semverRangevalid)
 
 ### `semver`
 
-Starts the chain. Does not perform any validation in itself. The reason for this is that it is possible to continue with [`semver.validRange()`](#semvervalidrange) in which
-case the expected value should be a range instead of a version.
+Starts the chain.
 
-### `semver.valid()`
+#### `semver.valid()`
 Asserts `valid(value)`.
-### `semver.gt(exp)`
+#### `semver.gt(exp)`
 Asserts `gt(value, exp)`.
-### `semver.gte(exp)`
+#### `semver.gte(exp)`
 Asserts `gte(value, exp)`.
-### `semver.lt(exp)`
+#### `semver.lt(exp)`
 Asserts `lt(value, exp)`.
-### `semver.lte(exp)`
+#### `semver.lte(exp)`
 Asserts `lte(value, exp)`.
-### `semver.eq(exp)`
+#### `semver.eq(exp)`
 Asserts `eq(value, exp)`.
-### `semver.neq(exp)`
+#### `semver.neq(exp)`
 Asserts `neq(value, exp)`.
-### `semver.cmp(comp, exp)`
+#### `semver.cmp(comp, exp)`
 Asserts `cmp(value, comp, exp)`.
-### `semver.validRange()`
-Asserts `validRange(value)`.
-### `semver.satisfies(rng)`
+#### `semver.satisfies(rng)`
 Asserts `satisfies(value, rng)`.
-### `semver.gtr(rng)`
+#### `semver.gtr(rng)`
 Asserts `gtr(value, rng)`.
-### `semver.ltr(rng)`
+#### `semver.ltr(rng)`
 Asserts `ltr(value, rng)`.
-### `semver.outside(hilo, rng)`
+#### `semver.outside(hilo, rng)`
 Asserts `outside(value, hilo, rng)`.
+
+### `semverRange`
+
+Starts the chain.
+
+#### `semverRange.valid()`
+Asserts `validRange(value)`.

--- a/index.js
+++ b/index.js
@@ -5,93 +5,124 @@ const semver = require('semver')
 
 const extensionName = 'semver'
 
-const validRule = {
-  name: 'valid',
-  validate: function (params, value, state, options) {
-    return semver.valid(value) ? value : this.createError(`${extensionName}.valid`, { v: value }, state, options)
-  }
-}
-
-const simpleComparatorRules = ['gt', 'gte', 'lt', 'lte', 'eq', 'neq'].map(function (name) {
-  return {
-    name,
-    params: {
-      exp: Joi.string().required()
-    },
-    validate: function (params, value, state, options) {
-      return semver[name](value, params.exp) ? value : this.createError(`${extensionName}.${name}`, { v: value, exp: params.exp }, state, options)
-    }
-  }
-})
-
-const cmpRule = {
-  name: 'cmp',
-  params: {
-    cmp: Joi.string().required(),
-    exp: Joi.string().required()
-  },
-  validate: function (params, value, state, options) {
-    return semver.cmp(value, params.cmp, params.exp) ? value : this.createError(`${extensionName}.cmp`, { v: value, cmp: params.cmp, exp: params.exp }, state, options)
-  }
-}
-
-const validRangeRule = {
-  name: 'validRange',
-  validate: function (params, value, state, options) {
-    return semver.validRange(value) ? value : this.createError(`${extensionName}.validRange`, { v: value }, state, options)
-  }
-}
-
-const rangeComparatorRules = ['satisfies', 'gtr', 'ltr'].map(function (name) {
-  return {
-    name,
-    params: {
-      rng: Joi.string().required()
-    },
-    validate: function (params, value, state, options) {
-      return semver[name](value, params.rng) ? value : this.createError(`${extensionName}.${name}`, { v: value, rng: params.rng }, state, options)
-    }
-  }
-})
-
-const outsideRule = {
-  name: 'outside',
-  params: {
-    hilo: Joi.string().required(),
-    rng: Joi.string().required()
-  },
-  validate: function (params, value, state, options) {
-    return semver.outside(value, params.rng, params.hilo) ? value : this.createError(`${extensionName}.outside`, { v: value, hilo: params.hilo, rng: params.rng }, state, options)
-  }
-}
-
-const rules = []
-  .concat([validRule])
-  .concat(simpleComparatorRules)
-  .concat([cmpRule])
-  .concat([validRangeRule])
-  .concat(rangeComparatorRules)
-  .concat([outsideRule])
-
-const extension = {
+const semverRangeExtension = {
   base: Joi.string(),
-  name: 'semver',
-  language: {
-    valid: 'needs to be a valid semver expression',
-    gt: 'needs to be greater than {{exp}}',
-    gte: 'needs to be greater than or equal to {{exp}}',
-    lt: 'needs to be less than {{exp}}',
-    lte: 'needs to be less than or equal to {{exp}}',
-    eq: 'needs to be logically equivalent to {{exp}}',
-    neq: 'needs to be logically different than {{exp}}',
-    cmp: 'needs to satisfy {{cmp}} on {{exp}}',
-    validRange: 'needs to be a valid range',
-    satisfies: 'needs to satisfy {{rng}}',
-    gtr: 'needs to be greater than range {{rng}}',
-    ltr: 'needs to be less than range {{rng}}',
-    outside: 'needs to be {{hilo}} than range {{rng}}'
+  type: 'semverRange',
+  validate: function (value, { error }) {
+    return semver.validRange(value) ? { value } : { errors: error(`${extensionName}.valid`) }
+  },
+  messages: {
+    [`${extensionName}.valid`]: '"{{#label}}" needs to be a valid semver range'
+  }
+}
+
+const rules = {}
+
+rules.compare = {
+  method: false,
+  validate: function (value, helpers, { exp }, { name }) {
+    return semver[name](value, exp) ? value : helpers.error(`${extensionName}.${name}`, { exp })
+  },
+  args: [
+    {
+      name: 'exp',
+      assert: semver.valid,
+      message: 'needs to be a valid semver expression'
+    }
+  ]
+}
+;['gt', 'gte', 'lt', 'lte', 'eq', 'neq'].forEach(function (name) {
+  rules[name] = {
+    method: function (exp) {
+      return this.$_addRule({ name, method: 'compare', args: { exp } })
+    }
+  }
+})
+
+rules.cmp = {
+  method: function (cmp, exp) {
+    return this.$_addRule({ name: 'cmp', args: { cmp, exp } })
+  },
+  validate: function (value, helpers, { cmp, exp }) {
+    return semver.cmp(value, cmp, exp) ? value : helpers.error(`${extensionName}.cmp`, { cmp, exp })
+  },
+  args: [
+    {
+      name: 'cmp',
+      assert: (cmp) => ['===', '!==', '', '=', '==', '!=', '>', '>=', '<', '<='].includes(cmp),
+      message: 'needs to be a valid comparator'
+    },
+    {
+      name: 'exp',
+      assert: semver.valid,
+      message: 'needs to be a valid semver expression'
+    }
+  ]
+}
+
+rules.compareRange = {
+  method: false,
+  validate: function (value, helpers, { rng }, { name }) {
+    return semver[name](value, rng) ? value : helpers.error(`${extensionName}.${name}`, { rng })
+  },
+  args: [
+    {
+      name: 'rng',
+      assert: semver.validRange,
+      message: 'needs to be a valid semver range'
+    }
+  ]
+}
+;['satisfies', 'gtr', 'ltr'].forEach(function (name) {
+  rules[name] = {
+    method: function (rng) {
+      return this.$_addRule({ name, method: 'compareRange', args: { rng } })
+    }
+  }
+})
+
+rules.outside = {
+  method: function (hilo, rng) {
+    return this.$_addRule({ name: 'outside', args: { hilo, rng } })
+  },
+  validate: function (value, helpers, { hilo, rng }) {
+    return semver.outside(value, rng, hilo) ? value : helpers.error(`${extensionName}.outside`, { hilo, rng })
+  },
+  args: [
+    {
+      name: 'hilo',
+      assert: (hilo) => ['>', '<'].includes(hilo),
+      message: 'needs to be a valid comparator'
+    },
+    {
+      name: 'rng',
+      assert: semver.validRange,
+      message: 'needs to be a valid semver range'
+    }
+  ]
+}
+
+const semverExtension = {
+  base: Joi.string(),
+  type: 'semver',
+  validate: function (value, { error }) {
+    return semver.valid(value) ? { value } : { errors: error(`${extensionName}.valid`) }
+  },
+  messages: {
+    [`${extensionName}.valid`]: '"{{#label}}" needs to be a valid semver expression',
+    [`${extensionName}.gt`]: '"{{#label}}" needs to be greater than {{#exp}}',
+    [`${extensionName}.gte`]: '"{{#label}}" needs to be greater than or equal to {{#exp}}',
+    [`${extensionName}.lt`]: '"{{#label}}" needs to be less than {{#exp}}',
+    [`${extensionName}.lte`]: '"{{#label}}" needs to be less than or equal to {{#exp}}',
+    [`${extensionName}.eq`]: '"{{#label}}" needs to be logically equivalent to {{#exp}}',
+    [`${extensionName}.neq`]: '"{{#label}}" needs to be logically different than {{#exp}}',
+    [`${extensionName}.cmp`]: '"{{#label}}" needs to satisfy {{#cmp}} on {{#exp}}',
+    [`${extensionName}.satisfies`]: '"{{#label}}" needs to satisfy {{#rng}}',
+    [`${extensionName}.gtr`]: '"{{#label}}" needs to be greater than range {{#rng}}',
+    [`${extensionName}.ltr`]: '"{{#label}}" needs to be less than range {{#rng}}',
+    [`${extensionName}.outside`]: '"{{#label}}" needs to be {{#hilo}} than range {{#rng}}'
   },
   rules
 }
 
-module.exports = extension
+module.exports = { semver: semverExtension, semverRange: semverRangeExtension }

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ rules.compare = {
     }
   ]
 }
+
 ;['gt', 'gte', 'lt', 'lte', 'eq', 'neq'].forEach(function (name) {
   rules[name] = {
     method: function (exp) {
@@ -73,6 +74,7 @@ rules.compareRange = {
     }
   ]
 }
+
 ;['satisfies', 'gtr', 'ltr'].forEach(function (name) {
   rules[name] = {
     method: function (rng) {

--- a/index.spec.js
+++ b/index.spec.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const Joi = require('@hapi/joi').extend(require('.'))
+const { semver, semverRange } = require('.')
+const Joi = require('@hapi/joi').extend(semver).extend(semverRange)
 const { expect } = require('chai')
 
 describe('semver', function () {
@@ -76,14 +77,9 @@ describe('semver', function () {
     it('should reject version', function () {
       expect(function () { Joi.attempt('1.2.3', Joi.semver().cmp('=', '1.0.0')) }).to.throw(/"value" needs to satisfy = on 1\.0\.0/)
     })
-  })
-
-  describe('.validRange', function () {
-    it('should accept valid range', function () {
-      expect(Joi.attempt('1.2.3 - 1.8.0', Joi.semver().validRange())).to.eql('1.2.3 - 1.8.0')
-    })
-    it('should reject invalid range', function () {
-      expect(function () { Joi.attempt('a.b.c', Joi.semver().validRange()) }).to.throw(/"value" needs to be a valid range/)
+    it('should reject invalid params', function () {
+      expect(function () { Joi.attempt('1.2.3', Joi.semver().cmp('=', 'x.y.z')) }).to.throw(/exp needs to be a valid semver expression or reference/)
+      expect(function () { Joi.attempt('1.2.3', Joi.semver().cmp('foo', '1.0.0')) }).to.throw(/cmp needs to be a valid comparator or reference/)
     })
   })
 
@@ -122,6 +118,21 @@ describe('semver', function () {
     it('should reject version', function () {
       expect(function () { Joi.attempt('1.2.3', Joi.semver().outside('<', '~1.0.0')) }).to.throw(/"value" needs to be < than range ~1\.0\.0/)
       expect(function () { Joi.attempt('1.2.3', Joi.semver().outside('>', '~2.0.0')) }).to.throw(/"value" needs to be > than range ~2\.0\.0/)
+    })
+    it('should reject invalid params', function () {
+      expect(function () { Joi.attempt('1.2.3', Joi.semver().outside('>', 'x.y.z')) }).to.throw(/rng needs to be a valid semver range or reference/)
+      expect(function () { Joi.attempt('1.2.3', Joi.semver().outside('foo', '~1.0.0')) }).to.throw(/hilo needs to be a valid comparator or reference/)
+    })
+  })
+})
+
+describe('semverRange', function () {
+  describe('.valid', function () {
+    it('should accept valid range', function () {
+      expect(Joi.attempt('1.2.3 - 1.8.0', Joi.semverRange().valid())).to.eql('1.2.3 - 1.8.0')
+    })
+    it('should reject invalid range', function () {
+      expect(function () { Joi.attempt('a.b.c', Joi.semverRange().valid()) }).to.throw(/"value" needs to be a valid semver range/)
     })
   })
 })

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "author": "David Szakallas <david.szakallas@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "@hapi/joi": "^15.0.3",
+    "@hapi/joi": "^16.0.0",
     "chai": "^4.2.0",
     "eslint": "^5.16.0",
     "eslint-config-standard": "^12.0.0",
@@ -29,7 +29,7 @@
     "pre-commit": "^1.1.3"
   },
   "peerDependencies": {
-    "@hapi/joi": ">=15.0.0"
+    "@hapi/joi": ">=16.0.0"
   },
   "dependencies": {
     "semver": "^6.1.1"


### PR DESCRIPTION
Refs #12

I've managed to do this while _mostly_ maintaining backwards compatibility. However there is one exception. In Joi 16, the rule `valid` is a special rule name. Every type has a `valid()` and Calling `valid()` runs the special `validate()` method (which also runs when we instantiate). If you try to define a rule called `valid`, it will throw `Error: Rule conflict in semver valid`.

In the past we could perform no validation when we instantiate and then define both a `valid()` rule and a `validRange()` rule (as described in https://github.com/dszakallas/joi-extension-semver#semver ). As far as I can tell, rewriting the extension for Joi 16 means if `Joi.semver().valid()` validates a semver expression, we can't keep `Joi.semver().validRange()` because we have to check its a valid semver expression (as opposed to a range) in order to construct.

One thing I played with was moving `valid()` to `validVersion()`. That would give us

```js
Joi.semver().validVersion() //validate a version
Joi.semver().validRange() //validate a range
```

unfortunately because `valid()` is a 'special' function (even if we don't define `validate`, it will just exist and pass everything the passes the base type validation), that also leaves us with

```js
Joi.semver().valid() //passes everything
```

..which is undesirable and will silently produce very unexpected behaviour for those upgrading if they don't change their code.

I think the best solution here is to split the `validRange()` function out to a second extension, giving us

```js
Joi.semver().valid() //validate a version
Joi.semverRange().valid() //validate a range
```

This is the approach I've taken - treating a version and a range as 2 different types seems to be more in line with how Joi wants us to think of an extensions and data types.

I don't think there's a way to keep the existing extension interface with the new plugin architecture and I think the approach I've taken is the preferable of the two ways I've thought about, but I'm open to other ideas if anyone has any thoughts on it. I'm kinda fishing around in the dark a bit with the new plugin architecture as it is [not yet fully documented](https://github.com/hapijs/joi/issues/2011)

TODO:

Once we've settled on the design decision, I will:

- [x] Update the README to reflect the new interface
- [x] Update the CHANGELOG with upgrade advice
- [ ] ~Bump version in package.json~