### PR TITLE
Add types for TypeScript

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,5 @@ node_js: ["8", "10", "11", "12"]
 
 script:
   - npm run lint
+  - npm run lint:ts
   - npm test

--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "version": "4.0.0",
   "description": "Semver extension for the Joi validation library",
   "main": "index.js",
+  "types": "types",
   "scripts": {
     "lint": "eslint **/*.js",
+    "lint:ts": "dtslint types",
     "test": "nyc mocha index.spec.js"
   },
   "keywords": [
@@ -18,6 +20,7 @@
   "devDependencies": {
     "@hapi/joi": "^16.0.0",
     "chai": "^4.2.0",
+    "dtslint": "^3.5.1",
     "eslint": "^5.16.0",
     "eslint-config-standard": "^12.0.0",
     "eslint-plugin-import": "^2.17.3",
@@ -32,6 +35,7 @@
     "@hapi/joi": ">=16.0.0"
   },
   "dependencies": {
+    "@types/hapi__joi": "^16.0.12",
     "semver": "^6.1.1"
   },
   "repository": "dszakallas/joi-extension-semver",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,35 @@
+// TypeScript Version: 3.5
+
+import { Extension, AnySchema } from '@hapi/joi'
+
+export const semver: Extension
+export const semverRange: Extension
+
+export type Comparison = 'gt' | 'gte' | 'lt' | 'lte' | 'eq' | 'neq' | '===' | '!=='
+export type Hilo = '>' | '<'
+
+export interface SemverSchema extends AnySchema {
+  valid(): this
+  gt(exp: string): this
+  gte(exp: string): this
+  lt(exp: string): this
+  lte(exp: string): this
+  eq(exp: string): this
+  neq(exp: string): this
+  cmp(comp: Comparison, exp: string): this
+  satisfies(rng: string): this
+  gtr(rng: string): this
+  ltr(rng: string): this
+  outside(hilo: Hilo, rng: string): this
+}
+
+export interface SemverRangeSchema extends AnySchema {
+  valid(): this
+}
+
+declare module "@hapi/joi" {
+  interface Root {
+    semver(): SemverSchema
+    semverRange(): SemverRangeSchema
+  }
+}

--- a/types/tests.ts
+++ b/types/tests.ts
@@ -1,0 +1,20 @@
+import Joi from '@hapi/joi'
+import { semver, semverRange } from 'joi-extension-semver'
+
+Joi.extend(semver)
+Joi.extend(semverRange)
+
+Joi.semver().valid()
+Joi.semver().gt('1.2.3')
+Joi.semver().gte('1.2.3')
+Joi.semver().lt('1.2.3')
+Joi.semver().lte('1.2.3')
+Joi.semver().eq('1.2.3')
+Joi.semver().neq('1.2.3')
+Joi.semver().cmp('gt', '1.2.3')
+Joi.semver().satisfies('>1.2.3')
+Joi.semver().gtr('>1.2.3')
+Joi.semver().ltr('>1.2.3')
+Joi.semver().outside('>', '>1.2.3')
+
+Joi.semverRange().valid()

--- a/types/tsconfig.json
+++ b/types/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "lib": ["es6"],
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "baseUrl": ".",
+    "paths": { "joi-extension-semver": ["."] }
+  }
+}

--- a/types/tslint.json
+++ b/types/tslint.json
@@ -1,0 +1,7 @@
+{
+  "extends": "dtslint/dtslint.json",
+  "rules": {
+    "semicolon": false,
+    "space-before-function-paren": false
+  }
+}


### PR DESCRIPTION
This pulls in the type definition for `@hapi/joi` which simplifies things for TypeScript users, however it means non-TypeScript users are getting an extra (very small) dependency.

Feedback welcomed!

Closes #17